### PR TITLE
PlacedBlock: Change Ispect MessageStyle

### DIFF
--- a/src/main/java/com/example/BlockData.java
+++ b/src/main/java/com/example/BlockData.java
@@ -1,6 +1,7 @@
 package com.example;
 
 import net.minecraft.block.Block;
+import net.minecraft.text.Text;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -19,5 +20,14 @@ public class BlockData {
     public String getFormattedTimestamp() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         return this.timestamp.format(formatter);
+    }
+
+    public Text getFormattedDisplay() {
+        String format = Config.getInstance().getDisplayFormat();
+        String formattedText = format.replace("{Date}", getFormattedTimestamp())
+                .replace("{Player}", owner)
+                .replace("{Block}", block.getTranslationKey());
+
+        return Text.literal(formattedText);
     }
 }

--- a/src/main/java/com/example/Config.java
+++ b/src/main/java/com/example/Config.java
@@ -2,8 +2,9 @@ package com.example;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonSyntaxException;
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
 
 import java.io.File;
 import java.io.FileReader;
@@ -11,20 +12,12 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 public class Config {
-    private static final Gson GSON = new GsonBuilder()
-            .registerTypeAdapter(Config.class, new ConfigSerializer())
-            .setPrettyPrinting()
-            .create();
     private static final File CONFIG_FILE = new File("config/blockowner/config/config.json");
-
-    public String inspectTool = "minecraft:wooden_hoe";
-
     private static Config instance;
+    private String inspectTool = "minecraft:wooden_hoe";
+    private String displayFormat = "&0{Date} &6{Player} &1{Block}";
 
-    private Config() {
-        // Private constructor to prevent instantiation
-    }
-
+    // Singleton pattern
     public static Config getInstance() {
         if (instance == null) {
             instance = new Config();
@@ -33,34 +26,53 @@ public class Config {
         return instance;
     }
 
+    Config() {
+    }
+
+    public String getInspectTool() {
+        return inspectTool;
+    }
+
+    public void setInspectTool(String inspectTool) {
+        this.inspectTool = inspectTool;
+    }
+
+    public String getDisplayFormat() {
+        return displayFormat;
+    }
+
+    public void setDisplayFormat(String displayFormat) {
+        this.displayFormat = displayFormat;
+    }
+
     public void load() {
         if (CONFIG_FILE.exists()) {
             try (FileReader reader = new FileReader(CONFIG_FILE)) {
-                Config loadedConfig = GSON.fromJson(reader, Config.class);
-                if (loadedConfig != null) {
-                    this.inspectTool = loadedConfig.inspectTool;
-                    System.out.println("Config loaded: " + this.inspectTool);
-                } else {
-                    System.err.println("Loaded config is null, saving default config.");
-                    save();
-                }
-            } catch (IOException | JsonIOException | JsonSyntaxException e) {
-                System.err.println("Failed to load config: " + e.getMessage());
+                Gson gson = new GsonBuilder()
+                        .registerTypeAdapter(Config.class, new ConfigSerializer())
+                        .create();
+                instance = gson.fromJson(reader, Config.class);
+            } catch (IOException e) {
                 e.printStackTrace();
-                save(); // Save default config if loading fails
             }
         } else {
-            save();  // Save default config if it does not exist
+            save(); // Save default values if config file does not exist
         }
     }
 
     public void save() {
         try (FileWriter writer = new FileWriter(CONFIG_FILE)) {
-            GSON.toJson(this, writer);
-            System.out.println("Config saved: " + this.inspectTool);
+            Gson gson = new GsonBuilder()
+                    .registerTypeAdapter(Config.class, new ConfigSerializer())
+                    .setPrettyPrinting()
+                    .create();
+            gson.toJson(this, writer);
         } catch (IOException e) {
-            System.err.println("Failed to save config: " + e.getMessage());
             e.printStackTrace();
         }
+    }
+
+    public Item getInspectToolItem() {
+        return Registries.ITEM.get(new Identifier(inspectTool));
     }
 }

--- a/src/main/java/com/example/ConfigSerializer.java
+++ b/src/main/java/com/example/ConfigSerializer.java
@@ -1,12 +1,6 @@
 package com.example;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
+import com.google.gson.*;
 
 import java.lang.reflect.Type;
 
@@ -15,16 +9,21 @@ public class ConfigSerializer implements JsonSerializer<Config>, JsonDeserialize
     @Override
     public JsonElement serialize(Config src, Type typeOfSrc, JsonSerializationContext context) {
         JsonObject jsonObject = new JsonObject();
-        jsonObject.addProperty("inspectTool", src.inspectTool);
+        jsonObject.addProperty("inspectTool", src.getInspectTool());
+        jsonObject.addProperty("displayFormat", src.getDisplayFormat());
         return jsonObject;
     }
 
     @Override
     public Config deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         JsonObject jsonObject = json.getAsJsonObject();
-        String inspectTool = jsonObject.get("inspectTool").getAsString();
-        Config config = Config.getInstance();
-        config.inspectTool = inspectTool;
+        Config config = new Config();
+        if (jsonObject.has("inspectTool")) {
+            config.setInspectTool(jsonObject.get("inspectTool").getAsString());
+        }
+        if (jsonObject.has("displayFormat")) {
+            config.setDisplayFormat(jsonObject.get("displayFormat").getAsString());
+        }
         return config;
     }
 }

--- a/src/main/java/com/example/ExampleMod.java
+++ b/src/main/java/com/example/ExampleMod.java
@@ -5,6 +5,8 @@ import net.fabricmc.api.ModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.tools.Tool;
+
 public class ExampleMod implements ModInitializer {
 	// This logger is used to write text to the console and the log file.
 	// It is considered best practice to use your mod id as the logger's name.
@@ -22,5 +24,6 @@ public class ExampleMod implements ModInitializer {
 		EventHandlers.register();
 		LogLevelCommand.register();
 		ToolCommand.register();
+		MessageStyle.register();
 	}
 }

--- a/src/main/java/com/example/LogLevelCommand.java
+++ b/src/main/java/com/example/LogLevelCommand.java
@@ -29,19 +29,55 @@ public class LogLevelCommand {
         String level = StringArgumentType.getString(context, "logLevel").toLowerCase();
         switch (level) {
             case "none":
+                context.getSource().sendFeedback(() ->
+                                Text.literal("[BlockOwner] ")
+                                        .formatted(Formatting.GREEN)
+                                        .append(Text.literal("Log level set to:  ")
+                                                .formatted(Formatting.GRAY))
+                                        .append(Text.literal("NONE")
+                                                .formatted(Formatting.BLUE)),
+                        false
+                );
                 LoggerUtil.setLogLevel(LoggerUtil.LogLevel.NONE);
-                context.getSource().sendFeedback(() -> Text.literal("BlockOwner log level set to NONE").formatted(Formatting.GREEN), false);
+                //context.getSource().sendFeedback(() -> Text.literal("BlockOwner log level set to NONE").formatted(Formatting.GREEN), false);
                 break;
             case "minimal":
                 LoggerUtil.setLogLevel(LoggerUtil.LogLevel.MINIMAL);
-                context.getSource().sendFeedback(() -> Text.literal("BlockOwner log level set to MINIMAL").formatted(Formatting.GREEN), false);
+                context.getSource().sendFeedback(() ->
+                                Text.literal("[BlockOwner] ")
+                                        .formatted(Formatting.GREEN)
+                                        .append(Text.literal("Log level set to:  ")
+                                                .formatted(Formatting.GRAY))
+                                        .append(Text.literal("MINIMAL")
+                                                .formatted(Formatting.BLUE)),
+                        false
+                );
+                //context.getSource().sendFeedback(() -> Text.literal("BlockOwner log level set to MINIMAL").formatted(Formatting.GREEN), false);
                 break;
             case "all":
                 LoggerUtil.setLogLevel(LoggerUtil.LogLevel.ALL);
-                context.getSource().sendFeedback(() -> Text.literal("BlockOwner log level set to ALL").formatted(Formatting.GREEN), false);
+                context.getSource().sendFeedback(() ->
+                                Text.literal("[BlockOwner] ")
+                                        .formatted(Formatting.GREEN)
+                                        .append(Text.literal("Log level set to:  ")
+                                                .formatted(Formatting.GRAY))
+                                        .append(Text.literal("ALL")
+                                                .formatted(Formatting.BLUE)),
+                        false
+                );
+                //context.getSource().sendFeedback(() -> Text.literal("BlockOwner log level set to ALL").formatted(Formatting.GREEN), false);
                 break;
             default:
-                context.getSource().sendFeedback(() -> Text.literal("Invalid log level: " + level).formatted(Formatting.RED), false);
+                context.getSource().sendFeedback(() ->
+                                Text.literal("[BlockOwner] ")
+                                        .formatted(Formatting.GREEN)
+                                        .append(Text.literal("Invalid log level: ")
+                                                .formatted(Formatting.GRAY))
+                                        .append(Text.literal(level)
+                                                .formatted(Formatting.BLUE)),
+                        false
+                );
+                //context.getSource().sendFeedback(() -> Text.literal("Invalid log level: " + level).formatted(Formatting.RED), false);
                 return 0;
         }
         return SINGLE_SUCCESS;

--- a/src/main/java/com/example/MessageStyle.java
+++ b/src/main/java/com/example/MessageStyle.java
@@ -1,0 +1,66 @@
+package com.example;
+
+import com.mojang.brigadier.arguments.StringArgumentType;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+public class MessageStyle {
+
+    // This will be initially loaded from the config
+    static String displayFormat = Config.getInstance().getDisplayFormat();
+
+    public static void register() {
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, dedicated) -> {
+            dispatcher.register(CommandManager.literal("blockowner")
+                    .then(CommandManager.literal("style")
+                            .then(CommandManager.argument("format", StringArgumentType.greedyString())
+                                    .executes(context -> {
+                                        String format = StringArgumentType.getString(context, "format");
+                                        Config.getInstance().setDisplayFormat(format);
+
+                                        context.getSource().sendFeedback(() ->
+                                                        Text.literal("[BlockOwner] ")
+                                                                .formatted(Formatting.GREEN)
+                                                                .append(Text.literal("Display format set to: ")
+                                                                        .formatted(Formatting.GRAY))
+                                                                .append(Text.literal(applyMinecraftFormatting(format))),
+                                                false
+                                        );
+                                        return 1;
+                                    }))));
+        });
+    }
+
+    private static void setDisplayFormat(ServerCommandSource source, String format) {
+        displayFormat = format;
+        Config.getInstance().setDisplayFormat(format); // Save to config
+        source.sendFeedback(() -> Text.literal("BlockOwner display format set to:"), false);
+        source.sendFeedback(() -> Text.literal(applyMinecraftFormatting(format)), false);
+    }
+
+    public static String getDisplayFormat() {
+        return displayFormat;
+    }
+
+    public static String applyFormat(BlockData blockData) {
+        Config config = Config.getInstance();
+        String displayFormat = config.getDisplayFormat();
+
+        String formattedText = displayFormat;
+        formattedText = formattedText.replace("{Player}", blockData.owner);
+        formattedText = formattedText.replace("{Block}", blockData.block.getName().getString());  // Get the localized block name
+        formattedText = formattedText.replace("{Date}", blockData.getFormattedTimestamp());
+
+        return applyMinecraftFormatting(formattedText);
+    }
+
+    private static String applyMinecraftFormatting(String text) {
+        return text.replaceAll("&([0-9a-fk-or])", "§$1");
+    }
+}

--- a/src/main/java/com/example/ToolCommand.java
+++ b/src/main/java/com/example/ToolCommand.java
@@ -27,9 +27,18 @@ public class ToolCommand {
 
     private static int setTool(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ItemStack itemStack = ItemStackArgumentType.getItemStackArgument(context, "tool").createStack(1, false);
-        config.inspectTool = itemStack.getItem().toString();
+        config.setInspectTool(itemStack.getItem().toString());
         config.save();
-        context.getSource().sendFeedback(() -> Text.literal("Inspect tool set to: " + config.inspectTool).formatted(Formatting.AQUA), true);
+        context.getSource().sendFeedback(() ->
+                        Text.literal("[BlockOwner] ")
+                                .formatted(Formatting.GREEN)
+                                .append(Text.literal("Inspect tool set to:  ")
+                                        .formatted(Formatting.GRAY))
+                                .append(Text.literal(config.getInspectTool())
+                                        .formatted(Formatting.AQUA)),
+                false
+        );
+        //context.getSource().sendFeedback(() -> Text.literal("Inspect tool set to: " + config.getInspectTool()).formatted(Formatting.AQUA), true);
         return SINGLE_SUCCESS;
     }
 }


### PR DESCRIPTION
- User can now set the inspectMessage using a command in any order they want some example commands: `/blockowner style &1{Block} &2{User} &5{Date}`
`/blockowner style  &2{User} &2{Date} &5{Block}`
- MessageOutput has been improved with branding
- Fixed an issue where default inspectTool was not set